### PR TITLE
Simplify decode() and validate UTF-8 continuation bytes

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -529,6 +529,25 @@ TEST_CASE("decode 3", "[utf8]") {
   REQUIRE(utf8::decode(u8text) == u32text);
 }
 
+TEST_CASE("decode invalid utf8 resync", "[utf8]") {
+  // An invalid lead byte must resync at the next byte and must not swallow the
+  // following valid characters.
+  REQUIRE(utf8::decode("\xE0" "AB") == U"AB");        // truncated 3-byte lead
+  REQUIRE(utf8::decode("\xF0" "Hello") == U"Hello");  // truncated 4-byte lead
+  REQUIRE(utf8::decode("\xE1\x80" "A") == U"A");       // bad 3rd byte
+  REQUIRE(utf8::decode("a\x80" "b") == U"ab");         // lone continuation byte
+  REQUIRE(utf8::decode("\xFF\xFF" "x") == U"x");        // never-valid lead bytes
+}
+
+TEST_CASE("decode_codepoint rejects bad continuation bytes", "[utf8]") {
+  char32_t cp;
+  // A continuation byte that is not 0x80-0xBF makes decode fail (0 bytes).
+  REQUIRE(utf8::decode_codepoint("\xE0" "AB", 3, cp) == 0);
+  REQUIRE(utf8::decode_codepoint("\xF0\x41\x42\x43", 4, cp) == 0);
+  // A well-formed sequence is still accepted and reports its length.
+  REQUIRE(utf8::decode_codepoint(u8"あ", 3, cp) == 3);
+}
+
 }  // namespace test_utf8
 
 //-----------------------------------------------------------------------------
@@ -611,6 +630,12 @@ TEST_CASE("utf16 decode 2", "[utf16]") {
 TEST_CASE("utf16 decode 3", "[utf16]") {
   REQUIRE(utf16::decode(u16text) == u32text);
   REQUIRE(utf16::decode(u16text) == u32text);
+}
+
+TEST_CASE("utf16 decode invalid resync", "[utf16]") {
+  // A lone high surrogate must resync and must not swallow the next unit.
+  const char16_t lone_high[] = {0xD800, u'A'};
+  REQUIRE(utf16::decode(std::u16string_view(lone_high, 2)) == U"A");
 }
 
 }  // namespace test_utf16

--- a/unicodelib_encodings.h
+++ b/unicodelib_encodings.h
@@ -161,14 +161,14 @@ inline bool decode_codepoint(const char *s8, size_t l, size_t &bytes,
       cp = b;
       return true;
     } else if ((b & 0xE0) == 0xC0) {
-      if (l >= 2) {
+      if (l >= 2 && (s8[1] & 0xC0) == 0x80) {
         bytes = 2;
         cp = ((static_cast<char32_t>(s8[0] & 0x1F)) << 6) |
              (static_cast<char32_t>(s8[1] & 0x3F));
         return true;
       }
     } else if ((b & 0xF0) == 0xE0) {
-      if (l >= 3) {
+      if (l >= 3 && (s8[1] & 0xC0) == 0x80 && (s8[2] & 0xC0) == 0x80) {
         bytes = 3;
         cp = ((static_cast<char32_t>(s8[0] & 0x0F)) << 12) |
              ((static_cast<char32_t>(s8[1] & 0x3F)) << 6) |
@@ -176,7 +176,8 @@ inline bool decode_codepoint(const char *s8, size_t l, size_t &bytes,
         return true;
       }
     } else if ((b & 0xF8) == 0xF0) {
-      if (l >= 4) {
+      if (l >= 4 && (s8[1] & 0xC0) == 0x80 && (s8[2] & 0xC0) == 0x80 &&
+          (s8[3] & 0xC0) == 0x80) {
         bytes = 4;
         cp = ((static_cast<char32_t>(s8[0] & 0x07)) << 18) |
              ((static_cast<char32_t>(s8[1] & 0x3F)) << 12) |
@@ -197,29 +198,15 @@ inline size_t decode_codepoint(const char *s8, size_t l, char32_t &out) {
   return 0;
 }
 
-template <typename T>
-inline void for_each(const char *s8, size_t l, T callback) {
-  size_t id = 0;
-  size_t i = 0;
-  while (i < l) {
-    auto beg = i++;
-    while (i < l && (s8[i] & 0xc0) == 0x80) {
-      i++;
-    }
-    callback(s8, l, beg, i, id++);
-  }
-}
-
 inline void decode(const char *s8, size_t l, std::u32string &out) {
-  for_each(
-      s8, l,
-      [&](const char *s, size_t /*l*/, size_t beg, size_t end, size_t /*i*/) {
-        size_t bytes;
-        char32_t cp;
-        if (decode_codepoint(&s[beg], (end - beg), bytes, cp)) {
-          out += cp;
-        }
-      });
+  for (size_t i = 0, bytes; i < l; i += bytes) {
+    char32_t cp;
+    if (decode_codepoint(&s8[i], l - i, bytes, cp)) {
+      out += cp;
+    } else {
+      bytes = 1;
+    }
+  }
 }
 
 }  // namespace utf8
@@ -331,29 +318,15 @@ inline size_t decode_codepoint(const char16_t *s16, size_t l, char32_t &out) {
   return 0;
 }
 
-template <typename T>
-inline void for_each(const char16_t *s16, size_t l, T callback) {
-  size_t id = 0;
-  size_t i = 0;
-  while (i < l) {
-    auto beg = i++;
-    if (is_surrogate_pair(&s16[beg], l - beg)) {
-      i++;
-    }
-    callback(s16, l, beg, i, id++);
-  }
-}
-
 inline void decode(const char16_t *s16, size_t l, std::u32string &out) {
-  for_each(s16, l,
-           [&](const char16_t *s, size_t /*l*/, size_t beg, size_t end,
-               size_t /*i*/) {
-             size_t length;
-             char32_t cp;
-             if (decode_codepoint(&s[beg], (end - beg), length, cp)) {
-               out += cp;
-             }
-           });
+  for (size_t i = 0, length; i < l; i += length) {
+    char32_t cp;
+    if (decode_codepoint(&s16[i], l - i, length, cp)) {
+      out += cp;
+    } else {
+      length = 1;
+    }
+  }
 }
 
 }  // namespace utf16


### PR DESCRIPTION
## Summary

Builds on #15 by @samhocevar, with one correctness fix added.

- **Simplify & speed up `decode()`** — remove the internal `for_each()` helpers (UTF-8 and UTF-16) and call `decode_codepoint()` directly. This drops the duplicated byte scan and speeds up decoding by roughly **20% (UTF-16)** and **30% (UTF-8)**. The helpers were used nowhere outside `decode()`.
- **Validate UTF-8 continuation bytes** in `decode_codepoint()`. Without the `for_each()` grouping, an invalid lead byte would consume the following bytes unconditionally — they were only masked with `& 0x3F`, never checked — and **swallow trailing valid characters**. Rejecting bytes that are not `0x80`–`0xBF` makes `decode()` resync byte-by-byte and recover the following text.

## Why the validation is needed

The bare simplification in #15 changes behaviour on **invalid** UTF-8 (valid input is unaffected):

| input | before this fix | with continuation validation | ICU / Python / Rust / browsers |
|---|---|---|---|
| `E0 41 42` | `B` (swallows `A`, bogus cp) | `AB` | `<U+FFFD>AB` |
| `F0 'Hello'` | `<U+896C>lo` (swallows `Hel`) | `Hello` | `<U+FFFD>Hello` |
| `E1 80 41` | `<U+1001>` (swallows `A`) | `A` | `<U+FFFD>A` |

Every mainstream decoder validates continuation bytes and never swallows the following valid characters. This change brings the resync behaviour in line with them. (The library still silently drops invalid bytes rather than emitting U+FFFD — that existing design choice is preserved; this PR is not a full Table 3-7 validator.)

## Tests

Added regression tests (`test/test.cpp`):

- `decode invalid utf8 resync` — invalid lead bytes resync and recover the following text instead of swallowing it.
- `decode_codepoint rejects bad continuation bytes` — `decode_codepoint()` returns 0 on bad continuation bytes, and still accepts well-formed sequences.
- `utf16 decode invalid resync` — a lone high surrogate resyncs without swallowing the next unit.

These fail against the un-validated `decode()` and pass with the fix.

## Verification

- Full test suite (including the new cases): **all pass**.
- ~500k random valid scalars, `encode → decode` round-trip: **0 failures** (UTF-8 and UTF-16), so no regression on valid input.
- 100k fuzzed byte sequences vs Python's standard decoder (`errors='replace'`, U+FFFD stripped): **98.3% exact match**; every remaining difference is the library's pre-existing permissiveness (overlong / surrogate-encoded / out-of-range), with no unexplained mismatches.
- Builds clean under `-Wall -Wextra -Wshadow`.