### PR TITLE
Add input validation to encodings and property table lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ API
 
 ## Functions
 
+### Unicode Scalar Value
+
+```cpp
+bool is_scalar_value(char32_t cp); // false for surrogates and code points beyond U+10FFFF
+```
+
 ### Unicode Property
 
 #### General Category

--- a/scripts/gen_tables.py
+++ b/scripts/gen_tables.py
@@ -103,7 +103,10 @@ const auto D = {1}::{2};
             out.write(formatValue(defval))
     out.write("\n};\n")
 
-    out.write("""inline {} get_value(char32_t cp) {{
+    out.write("""inline {0} get_value(char32_t cp) {{
+  if (cp > 0x10FFFF) {{
+    return {1};
+  }}
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {{
@@ -113,7 +116,7 @@ const auto D = {1}::{2};
   return _block_values[i];
 }}
 }}
-""".format(type))
+""".format(type, formatValue(defval).rstrip(',')))
 
 #------------------------------------------------------------------------------
 # genGeneralCategoryPropertyTable

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -27,6 +27,30 @@ void split(const char *b, const char *e, char d, Fn fn) {
 }
 
 //-----------------------------------------------------------------------------
+// Unicode Scalar Value
+//-----------------------------------------------------------------------------
+
+TEST_CASE("is_scalar_value", "[scalar value]") {
+  REQUIRE(is_scalar_value(U'a') == true);
+  REQUIRE(is_scalar_value(0xD7FF) == true);
+  REQUIRE(is_scalar_value(0xD800) == false);  // Surrogate
+  REQUIRE(is_scalar_value(0xDFFF) == false);  // Surrogate
+  REQUIRE(is_scalar_value(0xE000) == true);
+  REQUIRE(is_scalar_value(0x10FFFF) == true);
+  REQUIRE(is_scalar_value(0x110000) == false);  // Beyond U+10FFFF
+}
+
+TEST_CASE("Property lookup beyond U+10FFFF", "[scalar value]") {
+  REQUIRE(general_category(0x110000) == GeneralCategory::Unassigned);
+  REQUIRE(general_category(0xFFFFFFFF) == GeneralCategory::Unassigned);
+  REQUIRE(is_letter(0x110000) == false);
+  REQUIRE(is_white_space(0xFFFFFFFF) == false);
+  REQUIRE(is_alphabetic(0x110000) == false);
+  REQUIRE(block(0x110000) == Block::Unassigned);
+  REQUIRE(script(0x110000) == Script::Unassigned);
+}
+
+//-----------------------------------------------------------------------------
 // General Category
 //-----------------------------------------------------------------------------
 
@@ -548,6 +572,52 @@ TEST_CASE("decode_codepoint rejects bad continuation bytes", "[utf8]") {
   REQUIRE(utf8::decode_codepoint(u8"あ", 3, cp) == 3);
 }
 
+TEST_CASE("decode_codepoint rejects ill-formed scalar values", "[utf8]") {
+  char32_t cp;
+  // Overlong sequences
+  REQUIRE(utf8::decode_codepoint("\xC0\xAF", 2, cp) == 0);
+  REQUIRE(utf8::decode_codepoint("\xC1\xBF", 2, cp) == 0);
+  REQUIRE(utf8::decode_codepoint("\xE0\x80\xAF", 3, cp) == 0);
+  REQUIRE(utf8::decode_codepoint("\xF0\x80\x80\xAF", 4, cp) == 0);
+  // Surrogates
+  REQUIRE(utf8::decode_codepoint("\xED\xA0\x80", 3, cp) == 0);  // U+D800
+  REQUIRE(utf8::decode_codepoint("\xED\xBF\xBF", 3, cp) == 0);  // U+DFFF
+  // Beyond U+10FFFF
+  REQUIRE(utf8::decode_codepoint("\xF4\x90\x80\x80", 4, cp) == 0);  // U+110000
+  REQUIRE(utf8::decode_codepoint("\xF5\x80\x80\x80", 4, cp) == 0);
+
+  // Boundaries that must stay valid
+  REQUIRE(utf8::decode_codepoint("\xC2\x80", 2, cp) == 2);
+  REQUIRE(cp == 0x0080);
+  REQUIRE(utf8::decode_codepoint("\xE0\xA0\x80", 3, cp) == 3);
+  REQUIRE(cp == 0x0800);
+  REQUIRE(utf8::decode_codepoint("\xED\x9F\xBF", 3, cp) == 3);
+  REQUIRE(cp == 0xD7FF);
+  REQUIRE(utf8::decode_codepoint("\xEE\x80\x80", 3, cp) == 3);
+  REQUIRE(cp == 0xE000);
+  REQUIRE(utf8::decode_codepoint("\xF4\x8F\xBF\xBF", 4, cp) == 4);
+  REQUIRE(cp == 0x10FFFF);
+}
+
+TEST_CASE("decode drops ill-formed sequences and resyncs", "[utf8]") {
+  REQUIRE(utf8::decode("\xC0\xAF" "A") == U"A");          // overlong '/'
+  REQUIRE(utf8::decode("\xED\xA0\x80" "A") == U"A");      // surrogate U+D800
+  REQUIRE(utf8::decode("\xF4\x90\x80\x80" "A") == U"A");  // U+110000
+}
+
+TEST_CASE("codepoint_length consistent with decode_codepoint", "[utf8]") {
+  REQUIRE(utf8::codepoint_length("\xE3\x81", 2) == 0);      // truncated
+  REQUIRE(utf8::codepoint_length("\x80", 1) == 0);          // continuation byte
+  REQUIRE(utf8::codepoint_length("\xED\xA0\x80", 3) == 0);  // surrogate
+  REQUIRE(utf8::codepoint_length("\xE3\x81\x82", 3) == 3);
+}
+
+TEST_CASE("codepoint_count with ill-formed input", "[utf8]") {
+  // never loops forever, and matches what decode() produces
+  REQUIRE(utf8::codepoint_count("a\x80" "b", 3) == 2);
+  REQUIRE(utf8::codepoint_count("\xF0" "Hello", 6) == 5);
+}
+
 }  // namespace test_utf8
 
 //-----------------------------------------------------------------------------
@@ -636,6 +706,42 @@ TEST_CASE("utf16 decode invalid resync", "[utf16]") {
   // A lone high surrogate must resync and must not swallow the next unit.
   const char16_t lone_high[] = {0xD800, u'A'};
   REQUIRE(utf16::decode(std::u16string_view(lone_high, 2)) == U"A");
+}
+
+TEST_CASE("utf16 is_surrogate_pair bounds", "[utf16]") {
+  // Must not read s16[1] when only one unit is available.
+  const char16_t lone_high[] = {0xD800};
+  REQUIRE(utf16::is_surrogate_pair(lone_high, 1) == false);
+}
+
+TEST_CASE("utf16 decode_codepoint rejects unpaired surrogates", "[utf16]") {
+  char32_t cp;
+  const char16_t high[] = {0xD800, u'A'};
+  const char16_t low[] = {0xDC00, u'A'};
+  REQUIRE(utf16::decode_codepoint(high, 2, cp) == 0);
+  REQUIRE(utf16::decode_codepoint(low, 2, cp) == 0);
+}
+
+TEST_CASE("utf16 decode drops unpaired surrogates", "[utf16]") {
+  const char16_t s[] = {0xDC00, u'A'};
+  REQUIRE(utf16::decode(s, 2) == U"A");
+}
+
+TEST_CASE("utf16 codepoint_length consistent with encode/decode", "[utf16]") {
+  // Invalid scalar values yield 0, as encode_codepoint does.
+  REQUIRE(utf16::codepoint_length(0xD800) == 0);
+  REQUIRE(utf16::codepoint_length(0x110000) == 0);
+  REQUIRE(utf16::codepoint_length(0x10FFFF) == 2);
+  // Unpaired surrogates yield 0, as decode_codepoint does.
+  const char16_t high[] = {0xD800};
+  const char16_t low[] = {0xDC00};
+  REQUIRE(utf16::codepoint_length(high, 1) == 0);
+  REQUIRE(utf16::codepoint_length(low, 1) == 0);
+}
+
+TEST_CASE("utf16 codepoint_count with unpaired surrogates", "[utf16]") {
+  const char16_t s[] = {0xD800, u'A', 0xDC00, u'B'};
+  REQUIRE(utf16::codepoint_count(s, 4) == 2);
 }
 
 }  // namespace test_utf16

--- a/unicodelib.h
+++ b/unicodelib.h
@@ -28,6 +28,16 @@ namespace unicode {
 constexpr auto Unicode_Version = "17.0.0";
 
 //-----------------------------------------------------------------------------
+// Unicode Scalar Value
+//-----------------------------------------------------------------------------
+
+// D76 in the Unicode Standard: any code point except surrogates.
+// Named 'is_scalar_value' to avoid colliding with std::is_scalar.
+inline bool is_scalar_value(char32_t cp) {
+  return cp < 0xD800 || (0xE000 <= cp && cp <= 0x10FFFF);
+}
+
+//-----------------------------------------------------------------------------
 // General Category
 //-----------------------------------------------------------------------------
 
@@ -3564,6 +3574,9 @@ static const GeneralCategory _block_values[] = {
  T::Co,T::Co,T::Co,T::Co,T::Co,T::Co,T::Co,D,
 };
 inline GeneralCategory get_value(char32_t cp) {
+  if (cp > 0x10FFFF) {
+    return D;
+  }
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {
@@ -5966,6 +5979,9 @@ static const uint64_t _block_values[] = {
  0,0,0,0,0,0,0,0,
 };
 inline uint64_t get_value(char32_t cp) {
+  if (cp > 0x10FFFF) {
+    return 0;
+  }
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {
@@ -8411,6 +8427,9 @@ static const uint32_t _block_values[] = {
  0,0,0,0,0,0,0,0,
 };
 inline uint32_t get_value(char32_t cp) {
+  if (cp > 0x10FFFF) {
+    return 0;
+  }
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {
@@ -17633,6 +17652,9 @@ static const Block _block_values[] = {
  T::SupplementaryPrivateUseAreaB,T::SupplementaryPrivateUseAreaB,T::SupplementaryPrivateUseAreaB,T::SupplementaryPrivateUseAreaB,T::SupplementaryPrivateUseAreaB,T::SupplementaryPrivateUseAreaB,T::SupplementaryPrivateUseAreaB,T::SupplementaryPrivateUseAreaB,
 };
 inline Block get_value(char32_t cp) {
+  if (cp > 0x10FFFF) {
+    return D;
+  }
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {
@@ -20058,6 +20080,9 @@ static const Script _block_values[] = {
  D,D,D,D,D,D,D,D,
 };
 inline Script get_value(char32_t cp) {
+  if (cp > 0x10FFFF) {
+    return D;
+  }
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {
@@ -21974,6 +21999,9 @@ static const int _block_values[] = {
  -1,-1,-1,-1,-1,-1,-1,-1,
 };
 inline int get_value(char32_t cp) {
+  if (cp > 0x10FFFF) {
+    return 0;
+  }
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {
@@ -24339,6 +24367,9 @@ static const NormalizationProperties _block_values[] = {
  {0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0},
 };
 inline NormalizationProperties get_value(char32_t cp) {
+  if (cp > 0x10FFFF) {
+    return {0,0,0};
+  }
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {
@@ -27708,6 +27739,9 @@ static const GraphemeBreak _block_values[] = {
  D,D,D,D,D,D,D,D,
 };
 inline GraphemeBreak get_value(char32_t cp) {
+  if (cp > 0x10FFFF) {
+    return D;
+  }
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {
@@ -30101,6 +30135,9 @@ static const WordBreak _block_values[] = {
  D,D,D,D,D,D,D,D,
 };
 inline WordBreak get_value(char32_t cp) {
+  if (cp > 0x10FFFF) {
+    return D;
+  }
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {
@@ -32520,6 +32557,9 @@ static const SentenceBreak _block_values[] = {
  D,D,D,D,D,D,D,D,
 };
 inline SentenceBreak get_value(char32_t cp) {
+  if (cp > 0x10FFFF) {
+    return D;
+  }
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {
@@ -33652,6 +33692,9 @@ static const Emoji _block_values[] = {
  D,D,D,D,D,D,D,D,
 };
 inline Emoji get_value(char32_t cp) {
+  if (cp > 0x10FFFF) {
+    return D;
+  }
   auto i = cp / _block_size;
   auto bl = _blocks[i];
   if (bl) {

--- a/unicodelib_encodings.h
+++ b/unicodelib_encodings.h
@@ -84,26 +84,30 @@ inline size_t codepoint_length(char32_t cp) {
   return 0;
 }
 
+inline bool decode_codepoint(const char *s8, size_t l, size_t &bytes,
+                             char32_t &cp);
+
 inline size_t codepoint_length(const char *s8, size_t l) {
-  if (l) {
-    uint8_t b = s8[0];
-    if ((b & 0x80) == 0) {
-      return 1;
-    } else if ((b & 0xE0) == 0xC0) {
-      return 2;
-    } else if ((b & 0xF0) == 0xE0) {
-      return 3;
-    } else if ((b & 0xF8) == 0xF0) {
-      return 4;
-    }
+  size_t bytes;
+  char32_t cp;
+  if (decode_codepoint(s8, l, bytes, cp)) {
+    return bytes;
   }
   return 0;
 }
 
 inline size_t codepoint_count(const char *s8, size_t l) {
   size_t count = 0;
-  for (size_t i = 0; i < l; i += codepoint_length(s8 + i, l - i)) {
-    count++;
+  size_t i = 0;
+  while (i < l) {
+    auto bytes = codepoint_length(s8 + i, l - i);
+    if (bytes) {
+      count++;
+      i += bytes;
+    } else {
+      // skip an ill-formed byte, as decode() does
+      i++;
+    }
   }
   return count;
 }
@@ -165,7 +169,8 @@ inline bool decode_codepoint(const char *s8, size_t l, size_t &bytes,
         bytes = 2;
         cp = ((static_cast<char32_t>(s8[0] & 0x1F)) << 6) |
              (static_cast<char32_t>(s8[1] & 0x3F));
-        return true;
+        // reject overlong sequences
+        return cp >= 0x0080;
       }
     } else if ((b & 0xF0) == 0xE0) {
       if (l >= 3 && (s8[1] & 0xC0) == 0x80 && (s8[2] & 0xC0) == 0x80) {
@@ -173,7 +178,8 @@ inline bool decode_codepoint(const char *s8, size_t l, size_t &bytes,
         cp = ((static_cast<char32_t>(s8[0] & 0x0F)) << 12) |
              ((static_cast<char32_t>(s8[1] & 0x3F)) << 6) |
              (static_cast<char32_t>(s8[2] & 0x3F));
-        return true;
+        // reject overlong sequences and surrogates
+        return cp >= 0x0800 && (cp < 0xD800 || cp >= 0xE000);
       }
     } else if ((b & 0xF8) == 0xF0) {
       if (l >= 4 && (s8[1] & 0xC0) == 0x80 && (s8[2] & 0xC0) == 0x80 &&
@@ -183,7 +189,8 @@ inline bool decode_codepoint(const char *s8, size_t l, size_t &bytes,
              ((static_cast<char32_t>(s8[1] & 0x3F)) << 12) |
              ((static_cast<char32_t>(s8[2] & 0x3F)) << 6) |
              (static_cast<char32_t>(s8[3] & 0x3F));
-        return true;
+        // reject overlong sequences and code points beyond U+10FFFF
+        return cp >= 0x10000 && cp < 0x110000;
       }
     }
   }
@@ -218,7 +225,7 @@ inline void decode(const char *s8, size_t l, std::u32string &out) {
 namespace utf16 {
 
 inline bool is_surrogate_pair(const char16_t *s16, size_t l) {
-  if (l > 0) {
+  if (l >= 2) {
     auto first = s16[0];
     if (0xD800 <= first && first < 0xDC00) {
       auto second = s16[1];
@@ -230,22 +237,45 @@ inline bool is_surrogate_pair(const char16_t *s16, size_t l) {
   return false;
 }
 
-inline size_t codepoint_length(char32_t cp) { return cp <= 0xFFFF ? 1 : 2; }
+inline size_t codepoint_length(char32_t cp) {
+  if (cp < 0xD800) {
+    return 1;
+  } else if (cp < 0xE000) {
+    // D800 - DFFF is invalid...
+    return 0;
+  } else if (cp < 0x10000) {
+    return 1;
+  } else if (cp < 0x110000) {
+    return 2;
+  }
+  return 0;
+}
 
 inline size_t codepoint_length(const char16_t *s16, size_t l) {
   if (l > 0) {
     if (is_surrogate_pair(s16, l)) {
       return 2;
     }
-    return 1;
+    auto first = s16[0];
+    if (first < 0xD800 || first >= 0xE000) {
+      return 1;
+    }
   }
   return 0;
 }
 
 inline size_t codepoint_count(const char16_t *s16, size_t l) {
   size_t count = 0;
-  for (size_t i = 0; i < l; i += codepoint_length(s16 + i, l - i)) {
-    count++;
+  size_t i = 0;
+  while (i < l) {
+    auto length = codepoint_length(s16 + i, l - i);
+    if (length) {
+      count++;
+      i += length;
+    } else {
+      // skip an unpaired surrogate, as decode() does
+      i++;
+    }
   }
   return count;
 }
@@ -300,7 +330,7 @@ inline bool decode_codepoint(const char16_t *s16, size_t l, size_t &length,
     }
 
     // Non surrogate
-    else {
+    else if (first < 0xD800 || first >= 0xE000) {
       cp = first;
       length = 1;
       return true;


### PR DESCRIPTION
Fixes #16.

## Summary

Implements the sanity checks proposed by @samhocevar in #16, plus a couple of related fixes found along the way. After this change, the decoders never produce a non-scalar `char32_t`, the property lookups are safe for any `char32_t` input, and the `codepoint_length`/`codepoint_count` family is consistent with `encode_codepoint`/`decode_codepoint`.

### Memory safety (both confirmed with ASan on the old code)

- **`utf16::is_surrogate_pair()`** read `s16[1]` out of bounds when `l == 1` (heap-buffer-overflow). Now requires `l >= 2`.
- **Property lookups** (`general_category()`, `is_letter()`, `script()`, …) indexed past the end of `_blocks[]` for code points beyond U+10FFFF (global-buffer-overflow, e.g. `is_letter(0x110000)`). All eleven generated `get_value()` functions now return the default value (`Cn` / `Unassigned` / `0`) for out-of-range input — the same approach as ICU's `u_charType()`, Java's `Character.getType(int)`, and Go's `unicode.IsLetter`. The guard is emitted by `gen_tables.py`, so the tables remain reproducible (regeneration is byte-identical apart from the guards).

### Decoder validation

- **`utf8::decode_codepoint()`** now rejects ill-formed sequences per Table 3-7 of the Unicode Standard: overlong encodings (`C0 AF`, …), surrogates (`ED A0 80`, …), and code points beyond U+10FFFF (`F4 90 80 80`, `F5`–`F7` leads). `decode()` therefore never emits a non-scalar value, matching ICU / Python / Rust / Go.
- **`utf16::decode_codepoint()`** now rejects unpaired **low** surrogates, as it already did for unpaired high surrogates.

### API consistency (the inconsistencies listed in #16)

- `utf8::codepoint_length(s8, l)` returns 0 for ill-formed or truncated input instead of a length that may exceed `l`; it now reports exactly what `decode_codepoint()` would consume.
- `utf16::codepoint_length(char32_t)` returns 0 for surrogates and values beyond U+10FFFF, consistent with `encode_codepoint()`.
- `utf16::codepoint_length(const char16_t*, l)` returns 0 for unpaired surrogates, consistent with `decode_codepoint()`.
- `codepoint_count()` (both encodings) skips ill-formed units the same way `decode()` does, so `codepoint_count(s) == decode(s).size()` always holds. This also fixes an infinite loop: the old code advanced by `codepoint_length()`, which could return 0, so e.g. `utf8::codepoint_count("a\x80b", 3)` never returned.

### New helper

- `is_scalar_value(char32_t)` — the validity check proposed in #16 (documented in the README). Named `is_scalar_value` rather than `is_scalar` because the latter is ambiguous with `std::is_scalar` in code that uses both `namespace std` and `namespace unicode`. (The snippet in #16 also had a small typo: `0xD8000` for `0xD800`.)

## Behavioural note

`utf8::decode()` previously passed through CESU-8-style surrogates, overlong forms, and `F5`–`F7` sequences as garbage code points; it now silently drops them, like every mainstream decoder. The library's existing design of not emitting U+FFFD is unchanged.

## Tests

13 new test cases: scalar-value checks, out-of-range property lookups, rejection of overlong/surrogate/out-of-range sequences with all boundary cases that must stay valid (U+0080, U+0800, U+D7FF, U+E000, U+10000, U+10FFFF), resync behaviour, `codepoint_length`/`codepoint_count` consistency, and the `is_surrogate_pair` bounds case.

## Verification

- Existing + new test suite: **all pass** (including the UCD-driven segmentation and normalization tests).
- ASan: both overflows reproduce on the old code and are clean on the new code.
- Exhaustive `encode → decode` round-trip over **all 1,112,064 scalar values**: 0 failures (no regression on valid input); `codepoint_length(char32_t)` agrees with `encode_codepoint()` for every code point.
- 200k-case fuzz vs Python's UTF-8 decoder (`errors='replace'`, U+FFFD stripped): **100% agreement** (before this change: 98.3%, the gap being the now-rejected ill-formed forms).
- 200k-case UTF-16 fuzz: decoded output contains only scalar values; `codepoint_count == decode().size()` and `codepoint_length == decode_codepoint` hold at every position (run under ASan).
- Builds clean under `-Wall -Wextra -Wshadow`.