### PR TITLE
Make all constant helper tables inline const

### DIFF
--- a/scripts/gen_tables.py
+++ b/scripts/gen_tables.py
@@ -335,7 +335,7 @@ def genSimpleCaseMappingTable(ucd):
                 codePointPrev = codePoint
                 i += 1
 
-    print("const std::unordered_map<char32_t, const char32_t*> _simple_case_mappings = {")
+    print("inline const std::unordered_map<char32_t, const char32_t*> _simple_case_mappings = {")
     for cp, upper, lower, title in items():
         print('{ 0x%08X, U"\\U%08X\\U%08X\\U%08X" },' % (cp, upper, lower, title))
     print("};")
@@ -381,7 +381,7 @@ def genSpecialCaseMappingTable(ucd):
                 yield cp, lower, title, upper, language, context, hasContext
 
     # Regular
-    print("const std::unordered_multimap<char32_t, SpecialCasing> _special_case_mappings = {")
+    print("inline const std::unordered_multimap<char32_t, SpecialCasing> _special_case_mappings = {")
     for cp, lower, title, upper, language, context, hasContext in items():
         if hasContext == True:
             print('{ 0x%08X, { %s, %s, %s, %s, SpecialCasingContext::%s } },'
@@ -390,7 +390,7 @@ def genSpecialCaseMappingTable(ucd):
     print("};")
 
     # Default
-    print("const std::unordered_multimap<char32_t, SpecialCasing> _special_case_mappings_default = {")
+    print("inline const std::unordered_multimap<char32_t, SpecialCasing> _special_case_mappings_default = {")
     for cp, lower, title, upper, language, context, hasContext in items():
         if hasContext == False:
             print('{ 0x%08X, { %s, %s, %s, %s, SpecialCasingContext::%s } },'
@@ -426,7 +426,7 @@ def genCaseFoldingTable(ucd):
             elif status == 'T':
                 dic[cp][3] = codes[0]
 
-    print("const std::unordered_map<char32_t, CaseFolding> _case_foldings = {")
+    print("inline const std::unordered_map<char32_t, CaseFolding> _case_foldings = {")
     for cp in dic:
         cf = dic[cp]
         f = to_unicode_literal(cf[2])
@@ -670,7 +670,7 @@ def genScriptExtensionTable(ucd):
 
     ids = {}
 
-    print("const std::vector<std::vector<Script>> _script_extension_properties_for_id = {")
+    print("inline const std::vector<std::vector<Script>> _script_extension_properties_for_id = {")
     for line in fin:
         m = r.match(line)
         if m:
@@ -804,7 +804,7 @@ def genNomalizationCompositionTable(ucd):
             else:
                 exclusions.add(first)
 
-    print("const std::unordered_map<std::u32string, char32_t> _normalization_composition = {")
+    print("inline const std::unordered_map<std::u32string, char32_t> _normalization_composition = {")
     for cp, codes in items():
         if not cp in exclusions:
             print('{ U"\\U%08X\\U%08X", 0x%08X },' % (codes[0], codes[1], cp))

--- a/unicodelib.h
+++ b/unicodelib.h
@@ -8558,7 +8558,7 @@ inline uint32_t get_value(char32_t cp) {
   return _block_values[i];
 }
 }
-const std::unordered_map<char32_t, const char32_t*> _simple_case_mappings = {
+inline const std::unordered_map<char32_t, const char32_t*> _simple_case_mappings = {
 { 0x00000041, U"\U00000041\U00000061\U00000041" },
 { 0x00000042, U"\U00000042\U00000062\U00000042" },
 { 0x00000043, U"\U00000043\U00000063\U00000043" },
@@ -11549,7 +11549,7 @@ const std::unordered_map<char32_t, const char32_t*> _simple_case_mappings = {
 { 0x0001E942, U"\U0001E920\U0001E942\U0001E920" },
 { 0x0001E943, U"\U0001E921\U0001E943\U0001E921" },
 };
-const std::unordered_multimap<char32_t, SpecialCasing> _special_case_mappings = {
+inline const std::unordered_multimap<char32_t, SpecialCasing> _special_case_mappings = {
 { 0x000003A3, { U"\U000003C2", U"\U000003A3", U"\U000003A3", 0, SpecialCasingContext::Final_Sigma } },
 { 0x00000307, { U"\U00000307", 0, 0, "lt", SpecialCasingContext::After_Soft_Dotted } },
 { 0x00000049, { U"\U00000069\U00000307", U"\U00000049", U"\U00000049", "lt", SpecialCasingContext::More_Above } },
@@ -11567,7 +11567,7 @@ const std::unordered_multimap<char32_t, SpecialCasing> _special_case_mappings = 
 { 0x00000069, { U"\U00000069", U"\U00000130", U"\U00000130", "tr", SpecialCasingContext::Unassigned } },
 { 0x00000069, { U"\U00000069", U"\U00000130", U"\U00000130", "az", SpecialCasingContext::Unassigned } },
 };
-const std::unordered_multimap<char32_t, SpecialCasing> _special_case_mappings_default = {
+inline const std::unordered_multimap<char32_t, SpecialCasing> _special_case_mappings_default = {
 { 0x000000DF, { U"\U000000DF", U"\U00000053\U00000073", U"\U00000053\U00000053", 0, SpecialCasingContext::Unassigned } },
 { 0x00000130, { U"\U00000069\U00000307", U"\U00000130", U"\U00000130", 0, SpecialCasingContext::Unassigned } },
 { 0x0000FB00, { U"\U0000FB00", U"\U00000046\U00000066", U"\U00000046\U00000046", 0, SpecialCasingContext::Unassigned } },
@@ -11672,7 +11672,7 @@ const std::unordered_multimap<char32_t, SpecialCasing> _special_case_mappings_de
 { 0x00001FC7, { U"\U00001FC7", U"\U00000397\U00000342\U00000345", U"\U00000397\U00000342\U00000399", 0, SpecialCasingContext::Unassigned } },
 { 0x00001FF7, { U"\U00001FF7", U"\U000003A9\U00000342\U00000345", U"\U000003A9\U00000342\U00000399", 0, SpecialCasingContext::Unassigned } },
 };
-const std::unordered_map<char32_t, CaseFolding> _case_foldings = {
+inline const std::unordered_map<char32_t, CaseFolding> _case_foldings = {
 { 0x00000041, { 0x00000061,  0x00000000, 0, 0x00000000 } },
 { 0x00000042, { 0x00000062,  0x00000000, 0, 0x00000000 } },
 { 0x00000043, { 0x00000063,  0x00000000, 0, 0x00000000 } },
@@ -20211,7 +20211,7 @@ inline Script get_value(char32_t cp) {
   return _block_values[i];
 }
 }
-const std::vector<std::vector<Script>> _script_extension_properties_for_id = {
+inline const std::vector<std::vector<Script>> _script_extension_properties_for_id = {
 {
     Script::Avestan, 
     Script::Carian, 
@@ -24498,7 +24498,7 @@ inline NormalizationProperties get_value(char32_t cp) {
   return _block_values[i];
 }
 }
-const std::unordered_map<std::u32string, char32_t> _normalization_composition = {
+inline const std::unordered_map<std::u32string, char32_t> _normalization_composition = {
 { U"\U00000041\U00000300", 0x000000C0 },
 { U"\U00000041\U00000301", 0x000000C1 },
 { U"\U00000041\U00000302", 0x000000C2 },


### PR DESCRIPTION
Without "inline const", these objects will be allocated and initialised once for every compilation unit that includes <unicodelib.h>. With this tiny change, the initialisation code will still be compiled multiple times, but will only be executed once at runtime, saving about 380 kB of memory for each compilation unit.